### PR TITLE
Fix SDK build for macos

### DIFF
--- a/src/blazingmq/_ext.pyx
+++ b/src/blazingmq/_ext.pyx
@@ -58,7 +58,7 @@ cdef _log_callback(const char *name,
                    int level,
                    const char *filename,
                    int line,
-                   const char *msg):
+                   const char *msg) noexcept:
     if not LOGGER.isEnabledFor(level):
         return
     rec = LOGGER.makeRecord(name, level, filename, line, msg, (), None)


### PR DESCRIPTION
Fixing compile error

Error compiling Cython file:
------------------------------------------------------------

from .exceptions import BrokerTimeoutError
from .exceptions import Error

LOGGER = logging.getLogger(__name__)

BallUtil.initBallSingleton(_log_callback)
                           ^
------------------------------------------------------------

src/bloomberg/bmq/_ext.pyx:38:27: Cannot assign type 'void (const char *, int, const char *, int, const char *) except * nogil' to 'void (*)(char *, int, char *, int, char *) noexcept'. Exception values are incompatible. Suggest adding 'noexcept' to the type of '_log_callback'.

<!-- Make sure your PR is linked to an issue as described in the
CONTRIBUTING.md document. Place the issue number under the PR description
after the '#' character. -->

Closes: #